### PR TITLE
Fix typos on engagemenet URL path and Declarative Pipeline example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The [DefectDojo](https://www.defectdojo.com/) Jenkins plugin that helps integrate Jenkins CI with syncing with DefectDojo.
 
-[DefectDojo](https://www.defectdojo.com/) automates away security drudgery. The data model allows for a high level of flexibility providing continuous feedback and optimization across entire security program and DevSecOps pipeline. 
+[DefectDojo](https://www.defectdojo.com/) automates away security drudgery. The data model allows for a high level of flexibility providing continuous feedback and optimization across entire security program and DevSecOps pipeline.
 
 It stores, normalizes, and deduplicates results from over 160 security tools and converts them to a single actionable report. With less noise in the system, DevSecOps activities are prioritized to match the SLAs set.
 
@@ -58,7 +58,7 @@ pipeline {
         stage('DefectDojoPublisher') {
             steps {
                 withCredentials([string(credentialsId: 'CREDENTIALS_ID', variable: 'API_KEY')]) {
-                    defectDojoPublisher(artifact: 'target/dependency-check-report.xml', productName: 'my-product', scanType: 'Dependency Check Scan', engagementName: 'ci/cd', defectDojoCredentialsId: API_KEY, sourceCodeUri: 'https://git.com/org/project.git', branchTag: 'main')
+                    defectDojoPublisher(artifact: 'target/dependency-check-report.xml', productName: 'my-product', scanType: 'Dependency Check Scan', engagementName: 'ci/cd', defectDojoCredentialsId: API_KEY, sourceCodeUrl: 'https://git.com/org/project.git', branchTag: 'main')
                 }
             }
         }

--- a/src/main/java/io/jenkins/plugins/DefectDojo/ApiClient.java
+++ b/src/main/java/io/jenkins/plugins/DefectDojo/ApiClient.java
@@ -57,7 +57,7 @@ public class ApiClient {
 
     private static final String API_URL = "/api/v2";
     static final String API_KEY_HEADER = "Authorization";
-    static final String ENGAGEMENT_URL = API_URL + "/engagements/";
+    static final String ENGAGEMENT_URL = API_URL + "/engagement/";
     static final String UPLOAD_URL = API_URL + "/import-scan/";
     static final String REUPLOAD_URL = API_URL + "/reimport-scan/";
     static final String PRODUCT_URL = API_URL + "/products/";

--- a/src/main/java/io/jenkins/plugins/DefectDojo/DefectDojoPublisher.java
+++ b/src/main/java/io/jenkins/plugins/DefectDojo/DefectDojoPublisher.java
@@ -263,7 +263,7 @@ public final class DefectDojoPublisher extends Recorder implements SimpleBuildSt
         }
 
         logger.log(Messages.Builder_Success(String.format(
-                "%s/engagements/%s",
+                "%s/engagement/%s",
                 getEffectiveUrl(), StringUtils.isNotBlank(engagementId) ? engagementId : StringUtils.EMPTY)));
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- I've found that the link to the engagement screen displayed on the pipeline log is broken and includes a typo. I modified the URL path from `engagements` to `engagement`.

- There is another typo on the `Example` section on `README.md`. I modified the parameter from `sourceCodeUri` to `sourceCodeUrl` on the example code.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
